### PR TITLE
corrigir exibição de boolean, restringir escopo do grid e internalizar AppliedFilterItem

### DIFF
--- a/src/components/filter/index.tsx
+++ b/src/components/filter/index.tsx
@@ -372,7 +372,7 @@ const AppliedFilterTrigger = forwardRef<
     if (filterItem.type === 'date') {
       return filterItem.value.split('-').reverse().join('/')
     }
-    if (filterItem.type === 'boolean') return t(value)
+    if (filterItem.type === 'boolean') return t(filterItem.value)
     return filterItem.value.replaceAll('*', '')
   }, [filterItem.options, filterItem.type, filterItem.value, t])
 

--- a/src/components/filter/index.tsx
+++ b/src/components/filter/index.tsx
@@ -312,9 +312,7 @@ AppliedFiltersList.displayName = 'Filters.AppliedFiltersList'
 type AppliedFilterItemProps = {
   item: FilterItem
 }
-export const AppliedFilterItem: React.FC<AppliedFilterItemProps> = ({
-  item
-}) => {
+const AppliedFilterItem: React.FC<AppliedFilterItemProps> = ({ item }) => {
   const { originalFilter, onSelectFilter } = useFilterContext()
 
   const isOpen = useMemo(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,15 +52,19 @@
 .rsql-main {
   display: grid;
   grid-template:
-  'popover-trigger' min-content
-  'filters-list' min-content
-  / min-content;
+    'popover-trigger' min-content
+    'filters-list' min-content
+    / min-content;
   gap: 4px;
-}
 
-.rsql-popover-trigger {
-  grid-area: popover-trigger;
-  width: max-content;
+  .rsql-popover-trigger {
+    grid-area: popover-trigger;
+    width: max-content;
+  }
+
+  .rsql-filters {
+    grid-area: filters-list;
+  }
 }
 
 .rsql-filter-box {
@@ -155,7 +159,6 @@
 }
 
 .rsql-filters {
-  grid-area: filters-list;
   display: grid;
   grid-auto-flow: column;
   grid-template-rows: min-content;
@@ -177,7 +180,7 @@
   transition: background-color 0.2s;
   user-select: none;
 
-  &[data-state=open] {
+  &[data-state='open'] {
     background-color: #ccc;
   }
 }


### PR DESCRIPTION
- Corrige a tradução/exibição de valores booleanos usando o valor correto do filtro.
- Torna o componente AppliedFilterItem interno ao módulo, evitando exposição indevida na API pública.
- Ajusta estilos para que áreas de grid sejam aplicadas apenas dentro do contêiner principal e corrige o seletor de estado aberto para [data-state='open'].

Impacto (possível breaking change)
- AppliedFilterItem deixou de ser exportado. Se algum consumidor importava esse componente diretamente, deve migrar para os componentes públicos existentes (por exemplo, usar a lista de filtros aplicados) ou encapsular a própria apresentação.

Notas de QA
- Verificar que filtros booleanos exibem “true/false” traduzidos corretamente.
- Confirmar que a disposição do botão de abertura e da lista de filtros só é afetada dentro do contêiner principal.
- Garantir que o estilo de “estado aberto” é aplicado quando data-state='open'.
